### PR TITLE
fix: ft2build.h hasn't been included yet

### DIFF
--- a/src/fontsmodel.cpp
+++ b/src/fontsmodel.cpp
@@ -25,6 +25,7 @@
 #include <QDirIterator>
 
 // Freetype and Fontconfig
+#include <ft2build.h>
 #include <freetype/freetype.h>
 #include <fontconfig/fontconfig.h>
 #include <ft2build.h>


### PR DESCRIPTION
development environment: ubuntu 20.04.1 LTS
add header file of "ft2build.h" will solve this problem
![5807749ecb2128be05986577b88efe1](https://user-images.githubusercontent.com/22768973/102952374-fb6a4500-4509-11eb-922c-7b50fd6107bc.png)
