### PR TITLE
Add translators to About page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ compile_commands.json
 *creator.user*
 
 build/*
+.vscode/

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -108,6 +108,30 @@ ItemPage {
                 key: "小子"
                 value: "@Z-bin"
             }
+
+            HorizontalDivider {}
+
+            Label {
+                text: qsTr("CyberOS Translators")
+                color: Meui.Theme.disabledTextColor
+                topPadding: Meui.Units.largeSpacing
+                bottomPadding: Meui.Units.smallSpacing
+            }
+
+            StandardItem {
+                key: qsTr("Polish")
+                value: "omame (@omaemae)"
+            }
+
+            StandardItem {
+                key: qsTr("Simplified Chinese")
+                value: "Reven Martin (@rekols)"
+            }
+
+            StandardItem {
+                key: qsTr("Spanish")
+                value: "Sebastián (@Sebastian-byte)"
+            }
         }
     }
 }

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -48,6 +48,26 @@
         <source>CyberOS Team</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="115"/>
+        <source>CyberOS Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="122"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="127"/>
+        <source>Simplified Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="132"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AccountsPage</name>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -48,6 +48,26 @@
         <source>CyberOS Team</source>
         <translation>Equipo CyberOS</translation>
     </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="115"/>
+        <source>CyberOS Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="122"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="127"/>
+        <source>Simplified Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="132"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AccountsPage</name>

--- a/translations/pl_PL.ts
+++ b/translations/pl_PL.ts
@@ -50,6 +50,26 @@
         <source>CyberOS Team</source>
         <translation>Zespół CyberOS</translation>
     </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="115"/>
+        <source>CyberOS Translators</source>
+        <translation>Tłumaczenia CyberOS</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="122"/>
+        <source>Polish</source>
+        <translation>Polski</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="127"/>
+        <source>Simplified Chinese</source>
+        <translation>Chiński (uproszczony)</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="132"/>
+        <source>Spanish</source>
+        <translation>Hiszpański</translation>
+    </message>
 </context>
 <context>
     <name>AccountsPage</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -48,6 +48,26 @@
         <source>CyberOS Team</source>
         <translation>CyberOS 团队</translation>
     </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="115"/>
+        <source>CyberOS Translators</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="122"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="127"/>
+        <source>Simplified Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="132"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AccountsPage</name>


### PR DESCRIPTION
I'm not sure if you'll like it, so I made it a PR. Includes Polish translation.

English:
![image](https://user-images.githubusercontent.com/17727163/108054827-70ac4f00-704f-11eb-8712-14e1d105e053.png)

Polish:
![image](https://user-images.githubusercontent.com/17727163/108054880-86ba0f80-704f-11eb-8fd6-1a1c18f4ea42.png)
