### PR TITLE
Fix: replace qrand() with QRandomGenerator::bounded()

### DIFF
--- a/src/password.cpp
+++ b/src/password.cpp
@@ -1,5 +1,6 @@
 #include "password.h"
 
+#include <QRandomGenerator>
 #include <crypt.h>
 #include <unistd.h>
 
@@ -15,7 +16,7 @@ QString Password::cryptPassword(const QString &password) const
     QByteArray salt("$6$");
     int len = alpha.count();
     for (int i = 0; i < 16; i++)
-        salt.append(alpha.at((qrand() % len)));
+        salt.append(alpha.at((QRandomGenerator::global()->bounded(len))));
 
     return QString::fromLatin1(::crypt(password.toUtf8().constData(), salt.constData()));
 }


### PR DESCRIPTION
`qrand()` is deprecated.

See https://doc.qt.io/qt-5/qtglobal-obsolete.html#qrand & https://doc.qt.io/qt-5/qrandomgenerator.html#bounded-3